### PR TITLE
Default paginator indicators shouldn't have an 'active' class

### DIFF
--- a/BootstrapPresenter.php
+++ b/BootstrapPresenter.php
@@ -44,7 +44,7 @@ class BootstrapPresenter {
 	public function render()
 	{
 		// The hard-coded thirteen represents the minimum number of pages we need to
-		// ba able to create a sliding page window. If we have less than that, we
+		// be able to create a sliding page window. If we have less than that, we
 		// will just render a simple range of page links insteadof the sliding.
 		if ($this->lastPage < 13)
 		{


### PR DESCRIPTION
As said in the commits and title, default paginator indicators shouldn't have an 'active' class. The 'active' class was meant to indicate the current active page, not a clickable link to a page.

Also because of this, the 'active' class should never be used on 'previous' or 'next' links. 'Previous' or 'next' links are only meant to move towards the previous or next page in the sequence. They can't indicate an 'active' page stage because they aren't page indicators.

See the [Twitter Bootstrap docs](http://twitter.github.com/bootstrap/components.html#pagination) under `Pagination > Options > Disabled and active states` for more info.
