### PR TITLE
Update url() method to avoid SEO duplicate content issues with the first page

### DIFF
--- a/AbstractPaginator.php
+++ b/AbstractPaginator.php
@@ -166,16 +166,20 @@ abstract class AbstractPaginator implements Htmlable
         // If we have any extra query string key / value pairs that need to be added
         // onto the URL, we will put them in query string form and then attach it
         // to the URL. This allows for extra information like sortings storage.
-        $parameters = [$this->pageName => $page];
+        $parameters = $page > 1
+            ? [$this->pageName => $page]
+            : [];
 
         if (count($this->query) > 0) {
             $parameters = array_merge($this->query, $parameters);
         }
 
+        $separator = !empty($parameters) ? (Str::contains($this->path, '?') ? '&' : '?') : '';
+
         return $this->path
-                        .(Str::contains($this->path, '?') ? '&' : '?')
-                        .Arr::query($parameters)
-                        .$this->buildFragment();
+            .$separator
+            .http_build_query($parameters, '', '&')
+            .$this->buildFragment();
     }
 
     /**

--- a/AbstractPaginator.php
+++ b/AbstractPaginator.php
@@ -178,7 +178,7 @@ abstract class AbstractPaginator implements Htmlable
 
         return $this->path
             .$separator
-            .http_build_query($parameters, '', '&')
+            .Arr::query($parameters)
             .$this->buildFragment();
     }
 


### PR DESCRIPTION
Paginator will currently return the page query string parameter for the first page of pagination, when on proceeding pages. This introduces a potential SEO duplicate content issue, as the page now has 2 URLs, which a site owner would need to address via canonical links.

This PR changes the url() method of AbstractPaginator to only return the paging query string param for pages > 1.